### PR TITLE
Fix stringify() options to get pretty-printed file

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -30,7 +30,7 @@ function storeMetaData(metaData, file) {
 		, stream;
 
 	try {
-		json = JSON.stringify(metaData);
+		json = JSON.stringify(metaData,null,'\t');
 		stream = fs.createWriteStream(file);
 
 		stream.write(json);


### PR DESCRIPTION
I updated JSON.stringify() options so the output file is pretty-printed (like promised in README)