### PR TITLE
flaky updates for jasmine2

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You can modify the contents of the JSON meta data file by passing a function `me
 ```javascript
 new ScreenShotReporter({
    baseDirectory: '/tmp/screenshots'
-   , metaDataBuilder: function metaDataBuilder(spec, descriptions, results, capabilities) {
+   , metaDataBuilder: function metaDataBuilder(suite, spec, descriptions, results, capabilities) {
       // Return the description of the spec and if it has passed or not:
       return {
          description: descriptions.join(' ')

--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ ScreenshotReporter.prototype.suiteStarted =
 function suiteStarted(suite) {
 	//todo this doesnt seem to be called...
 	var self = this;
-	suite = getSuite(suite);
+	suite = self.getSuite(suite);
 	suite.parentSuite = self.currentSuite;
 	self.currentSuite = suite;
 };
@@ -134,7 +134,7 @@ ScreenshotReporter.prototype.suiteDone =
 function suiteDone(suite) {
 	//todo this doesnt seem to be called...
 	var self = this;
-	suite = getSuite(suite);
+	suite = self.getSuite(suite);
 	// disabled suite (xdescribe) -- suiteStarted was never called
 	if (suite.parentSuite === undefined) {
 		self.suiteStarted(suite);

--- a/lib/util.js
+++ b/lib/util.js
@@ -96,9 +96,25 @@ function generateGuid() {
     );
 }
 
+/** Function: extend
+ * Performs a shallow copy of all props of `obj` onto `dupe`
+ *
+ * Returns:
+ *     (Object) containing a shallow copy
+ */
+function extend(dupe, obj) { //
+	for (var prop in obj) {
+		if (obj.hasOwnProperty(prop)) {
+			dupe[prop] = obj[prop];
+		}
+	}
+	return dupe;
+}
+
 module.exports = {
 	storeScreenShot: storeScreenShot
 	, storeMetaData: storeMetaData
 	, gatherDescriptions: gatherDescriptions
 	, generateGuid: generateGuid
+	, extend: extend
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-screenshot-reporter",
-  "version": "0.0.5",
+  "version": "2.1.0",
   "description": "Use the screenshot reporter to capture screenshots from your Selenium nodes after each executed Protractor test case.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Problems:
suites is always null when passed to metadataBuilder and pathBuilder
suites logic was copied from jasmine-reporters package (specifically the TeamCityReporter), but isnt working

this is _good enough_ for jasmine2 in the mean time until a better update can be done

part of #20 
